### PR TITLE
Add support for custom code version

### DIFF
--- a/Rollbar/RollbarConfiguration.h
+++ b/Rollbar/RollbarConfiguration.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSUInteger, CaptureIpType) {
 - (void)setCaptureLogAsTelemetryData:(BOOL)captureLog;
 - (void)setCaptureConnectivityAsTelemetryData:(BOOL)captureConnectivity;
 - (void)setCaptureIpType:(CaptureIpType)captureIp;
+- (void)setCodeVersion:(NSString *)codeVersion;
 
 - (NSDictionary *)customData;
 
@@ -51,6 +52,8 @@ typedef NS_ENUM(NSUInteger, CaptureIpType) {
 @property (readonly, atomic, copy) NSString *personId;
 @property (readonly, atomic, copy) NSString *personUsername;
 @property (readonly, atomic, copy) NSString *personEmail;
+@property (readonly, nonatomic, copy) NSString *codeVersion;
+
 
 // Modify payload
 @property (atomic, copy) void (^payloadModification)(NSMutableDictionary *payload);

--- a/Rollbar/RollbarConfiguration.m
+++ b/Rollbar/RollbarConfiguration.m
@@ -122,6 +122,11 @@ static NSString *configurationFilePath = nil;
     [self save];
 }
 
+- (void)setCodeVersion:(NSString *)codeVersion {
+    _codeVersion = codeVersion;
+    [self save];
+}
+
 - (void)setCodeFramework:(NSString *)framework {
     self.framework = framework ? framework : FRAMEWORK;
     [self save];

--- a/Rollbar/RollbarNotifier.m
+++ b/Rollbar/RollbarNotifier.m
@@ -263,6 +263,10 @@ static BOOL isNetworkReachable = YES;
     NSBundle *mainBundle = [NSBundle mainBundle];
     
     NSString *version = [mainBundle objectForInfoDictionaryKey:(NSString*)kCFBundleVersionKey];
+    if (self.configuration.codeVersion.length > 0) {
+        version = self.configuration.codeVersion;
+    }
+    
     NSString *shortVersion = [mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *bundleName = [mainBundle objectForInfoDictionaryKey:(NSString *)kCFBundleNameKey];
     NSString *bundleIdentifier = [mainBundle objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey];


### PR DESCRIPTION
To resolve our version issue. We are unable to set `code_version` right now. This results in not very appropriate version numbers as can be seen here: https://rollbar.com/Instacart/instashopper-ios/versions/

This is in response to: https://github.com/rollbar/rollbar-ios/issues/157